### PR TITLE
feat/ cicd-workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-lates
+    runs-on: self-hosted
     
     steps:
       -

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-lates
+    
     steps:
       -
         name: Checkout
@@ -37,6 +38,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile-prod
+          platforms: linux/arm64/v8
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
## What is this PR?

개발환경, Github Runner, 그리고 배포환경이 동일하지 않습니다.
개발환경은 arm m1(RISC), Runner (CISC), 배포환경(RISC) 여서 몇가지 문제가 발생하는 것을 발견했습니다.

현재 Runner에서 arm으로 build를 진행하면 QEMU 이슈로 진행이 되지 않는 것을 발견했습니다. 따라서 Runner를 별도의 ARM 기반 VM을 생성하고 구축하여 해결하고자 합니다.

따라서 도커빌드 파일의 설정도 arm64/v8로 돌아가도록 수정이 필요했습니다.

-

## Changes

- 액션 파일의 빌드 부분을 arm64/v8로 인식하도록 수정했습니다.
- 코드 수정에는 포함되지 않지만 셀프 Action Runner 추가도 같이 진행했다는 커맨트 남깁니다.

## ScreenShot

- X

## Discussion

- X

## Test CheckList

- X
